### PR TITLE
TMC-217 | Select component update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.9
+
+### Features
+* Added `dropdown-top` and `dropdown-bottom` slots to `Select` component
+* Added `maxHeight` prop to `Popper` component
+    
+### Maintenance
+* `Select` component fixes:
+    - Fixed dropdown's bug with list overflowing
+    - Fixed inner popper's behavior when there're some `Select` components on the page 
+* Fixed `Scrollbar`'s overflow-x property when horizontal scroll is hidden 
+
+
+
+
 ## 0.2.8
 
 ### Features

--- a/src/components/popper/script.ts
+++ b/src/components/popper/script.ts
@@ -32,6 +32,9 @@ export default class StPopper extends Vue {
   @Prop(Number)
   width?: number;
 
+  @Prop(Number)
+  maxHeight?: number;
+
   @Prop({ type: Number, default: 100 })
   delayOnMouseOut!: number;
 
@@ -329,12 +332,9 @@ export default class StPopper extends Vue {
   }
 
   get popperStyles() {
-    if (!this.width) {
-      return {};
-    }
-
     return {
-      width: `${this.width}px`,
+      width: this.width ? `${this.width}px` : void 0,
+      maxHeight: this.maxHeight ? `${this.maxHeight}px` : void 0,
     };
   }
 }

--- a/src/components/scrollbar/script.ts
+++ b/src/components/scrollbar/script.ts
@@ -339,7 +339,9 @@ export default class StScrollbar extends Vue {
   get containerStyles() {
     return {
       width: `calc(100% + ${this.verticalScrollbarSize}px)`,
-      height: `calc(100% + ${this.horizontalScrollbarSize}px)`,
+      height: this.horizontalScrollData.isVisible
+        ? `calc(100% + ${this.horizontalScrollbarSize}px)`
+        : '100%',
     };
   }
 

--- a/src/components/scrollbar/style.scss
+++ b/src/components/scrollbar/style.scss
@@ -10,6 +10,10 @@
 
   &__container {
     overflow: scroll;
+
+    &--x-hidden {
+      overflow-x: hidden;
+    }
   }
 
   &__vertical-scroll {

--- a/src/components/scrollbar/template.html
+++ b/src/components/scrollbar/template.html
@@ -28,6 +28,9 @@
              :style="horizontalScrollStyles"></div>
     </div>
     <div class="st-scrollbar__container"
+         :class="{
+            'st-scrollbar__container--x-hidden': !horizontalScrollData.isVisible,
+         }"
          :style="containerStyles"
          ref="container"
          v-on="$listeners || {}">

--- a/src/components/select/_select-dropdown/script.ts
+++ b/src/components/select/_select-dropdown/script.ts
@@ -53,7 +53,7 @@ export default class StSelectDropdown extends Vue {
     placement: PopperPlacement.bottom,
     trigger: TriggerType.click,
     boundariesSelector: 'body',
-    stopPropagation: true,
+    appendToBody: false,
   };
 
   get popperClassName(): string {

--- a/src/components/select/_select-dropdown/style.scss
+++ b/src/components/select/_select-dropdown/style.scss
@@ -2,6 +2,7 @@
 
 .st-select-dropdown {
   box-sizing: border-box;
+  display: flex;
   width: $st-select-dropdown-width;
   max-height: $st-select-dropdown-list-max-height;
   padding: $st-select-dropdown-padding;
@@ -11,6 +12,8 @@
   box-shadow: $st-select-dropdown-shadow;
 
   &__content {
+    display: flex;
+    flex-direction: column;
     width: 100%;
   }
 

--- a/src/components/select/_select-dropdown/template.html
+++ b/src/components/select/_select-dropdown/template.html
@@ -9,6 +9,10 @@
     <slot name="reference"></slot>
   </template>
   <div class="st-select-dropdown__content">
+    <div v-if="$slots['dropdown-top']"
+         class="st-select-dropdown__slot st-select-dropdown__slot--top">
+      <slot name="dropdown-top" />
+    </div>
     <st-scrollbar class="st-select-dropdown__options-list">
       <slot :options="options">
         <div :class="[
@@ -31,5 +35,9 @@
         </div>
       </slot>
     </st-scrollbar>
+    <div v-if="$slots['dropdown-top']"
+         class="st-select-dropdown__slot st-select-dropdown__slot--bottom">
+      <slot name="dropdown-bottom" />
+    </div>
   </div>
 </st-popper>

--- a/src/components/select/_select-multiple/template.html
+++ b/src/components/select/_select-multiple/template.html
@@ -17,6 +17,12 @@
                     @select="select"
                     @dropdown-show="dropdownVisible = true; $emit('dropdown-show')"
                     @dropdown-hide="dropdownVisible = false; $emit('dropdown-hide')">
+  <template v-slot:dropdown-top>
+    <slot name="dropdown-top" />
+  </template>
+  <template v-slot:dropdown-bottom>
+    <slot name="dropdown-bottom" />
+  </template>
   <st-select-content slot="reference"
                      :value="selectedValues.join(',')"
                      :is-active="dropdownVisible"

--- a/src/components/select/_select-single/template.html
+++ b/src/components/select/_select-single/template.html
@@ -16,6 +16,12 @@
                     @select="select"
                     @dropdown-show="dropdownVisible = true; $emit('dropdown-show')"
                     @dropdown-hide="dropdownVisible = false; $emit('dropdown-hide')">
+  <template v-slot:dropdown-top>
+    <slot name="dropdown-top" />
+  </template>
+  <template v-slot:dropdown-bottom>
+    <slot name="dropdown-bottom" />
+  </template>
   <st-select-content slot="reference"
                      :value="selectedLabel"
                      :is-active="dropdownVisible"

--- a/src/components/select/template.html
+++ b/src/components/select/template.html
@@ -11,6 +11,8 @@
              :size="size"
              :prefix-icon="prefixIcon"
              :suffix-icon="suffixIcon"
+             :dropdown-popper-props="dropdownPopperProps"
+             :collapser-popper-props="collapserPopperProps"
              @input="$event => $emit('input', $event)"
              @select="$event => $emit('select', $event)"
              @clear="$emit('clear')"
@@ -21,6 +23,12 @@
     </template>
     <template v-slot:content-suffix>
       <slot name="suffix" />
+    </template>
+    <template v-slot:dropdown-top>
+      <slot name="dropdown-top" />
+    </template>
+    <template v-slot:dropdown-bottom>
+      <slot name="dropdown-bottom" />
     </template>
     <template v-slot:dropdown-list="{ options }">
       <slot name="list"

--- a/stories/documentation/popper.md
+++ b/stories/documentation/popper.md
@@ -7,6 +7,7 @@
 | v-model | manual popper trigger | false | boolean | - | - |
 | content | popper raw content | false | string | - | - |
 | width | popper width | false | number | - | - |
+| max-height | popper max-height | false | number | - | - |
 | tag | html tag for root element | false | string | span | - |
 | delay-on-mouse-over | delay mouse over on popper in milliseconds | false | number | 100 | - |
 | delay-on-mouse-out | delay mouse out of popper in milliseconds | false | number | 100 | - |

--- a/stories/documentation/select.md
+++ b/stories/documentation/select.md
@@ -43,13 +43,19 @@ Here's some examples:
   <template v-slot:suffix>
     <!-- any content -->
   </template>
+  <template v-slot:dropdown-top>
+    <!-- any content -->
+  </template>
+  <template v-slot:dropdown-bottom>
+    <!-- any content -->
+  </template>
   <template v-slot:option="{ option }">
     <st-icon name="location" /> {{ option.label }}
   </template>
 </st-select>
            
 <!-- Multiple select has some extra slots -->
-<st-select v-model="singleValue" 
+<st-select v-model="multipleValue" 
            :options="options"  
            multiple>
     <template v-slot:collapser-control="{ amount }">
@@ -62,6 +68,20 @@ Here's some examples:
       </div>
     </template>
 </st-select>
+```
+
+Also you can change/extend inner dropdown's props via `dropdown-popper-props` (same with `collapser-popper-props`):
+
+```html
+<st-select v-model="singleValue" 
+           :options="options" 
+           :dropdown-popper-props="{
+             width: 400,
+             maxHeight: 250,
+             arrowVisible: true,
+             placement: 'top',
+             trigger: 'hover',
+           }" />
 ```
 
 You can find out more about this component slots in the bottom of documentation. 
@@ -82,7 +102,7 @@ You can find out more about this component slots in the bottom of documentation.
 | prefixIcon | Defines prefix icon name (at the left side) | - | String | - | CHECK ICON COMPONENT |
 | suffixIcon | Defines suffix icon name (at the right side) | - | String | - | CHECK ICON COMPONENT |
 | dropdown-popper-props | Dropdown popper's component properties | - | Object | arrowVisible: false, placement: bottom, trigger: click, boundariesSelector: 'body' | CHECK POPPER COMPONENT DOCUMENTATION |
-| collapser-popper-props | **(Multiple Select only)** Collapser popper's component properties | - | Object | arrowVisible: true, placement: top, trigger: hover, boundariesSelector: 'body' | CHECK POPPER COMPONENT DOCUMENTATION |
+| collapser-popper-props | **(Multiple Select only)** Collapser popper's component properties | - | Object | arrowVisible: true, placement: top, trigger: hover, boundariesSelector: 'body', appendToBody: false | CHECK POPPER COMPONENT DOCUMENTATION |
 
 ## Events
 
@@ -100,6 +120,8 @@ You can find out more about this component slots in the bottom of documentation.
 | --- | --- | --- |
 | prefix | Defines prefix content in select (at the left as default) | - |
 | suffix | Defines suffix content in select (at the right as default) | - |
+| dropdown-top | Defines content in select's dropdown, above the list | - |
+| dropdown-bottom | Defines content in select's dropdown, below the list | - |
 | list | Defines select dropdown's list | { options } |
 | option | Defines select dropdown option's content | { option } |
 | collapser-control | **(Multiple Select only)** Defines collapser control's block content | { amount } |

--- a/stories/templates/select/default.template.js
+++ b/stories/templates/select/default.template.js
@@ -9,5 +9,6 @@ export const template = `
            :required="required"
            :clearable="clearable"
            :prefix-icon="prefixIcon"
-           :suffix-icon="suffixIcon"></st-select>
+           :suffix-icon="suffixIcon">
+</st-select>
 `;


### PR DESCRIPTION
* Added `dropdown-top` and `dropdown-bottom` slots to `Select` component
* Added `maxHeight` prop to `Popper` component
* `Select` component fixes:
    - Fixed dropdown's bug with list overflowing
    - Fixed inner popper's behavior when there're some `Select` components on the page 
* Fixed `Scrollbar`'s overflow-x property when horizontal scroll is hidden 
* Some examples at `Select` documentation were updated