### PR TITLE
TMC-390 | Fixed clear icon visibility when disabled or readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@
     - Fixed dropdown's bug with list overflowing
     - Fixed inner popper's behavior when there're some `Select` components on the page
 * Fixed `Scrollbar`'s overflow-x property when horizontal scroll is hidden
-* Fixed wrong background color of disabled `Input`
+* `Input` component fixes:
+    - Fixed wrong background color when disabled
+    - Fixed clear icon visibility when disabled or readonly
+    - Removed Firefox's outline when inner input is `:invalid`
 
 
 

--- a/src/components/input/script.ts
+++ b/src/components/input/script.ts
@@ -74,7 +74,7 @@ export default class StInput extends Vue {
   inputFocused = false;
 
   get showCloseIcon() {
-    return this.clearable && !!this.inputValue;
+    return this.clearable && !this.readonly && !this.disabled && !!this.inputValue;
   }
 
   @Watch('value')

--- a/src/components/input/style.scss
+++ b/src/components/input/style.scss
@@ -48,11 +48,12 @@
     font-size: $st-input-font-size;
     line-height: 1;
     color: $st-input-color;
+    cursor: inherit;
     -webkit-appearance: none;
     border: none;
     outline: none;
 
-    /** disalbe default clear on IE */
+    /* Disable default clear on IE */
     &::-ms-clear {
       display: none;
       width: 0;
@@ -61,6 +62,11 @@
 
     &::placeholder {
       color: $st-input-placeholder-color;
+    }
+
+    /* Firefox default outline */
+    &:invalid {
+      box-shadow: none;
     }
   }
 

--- a/src/components/input/template.html
+++ b/src/components/input/template.html
@@ -6,9 +6,6 @@
         'st-input--readonly': readonly,
         'st-input--hovered': inputHovered,
         'st-input--focused': inputFocused,
-        'st-input--with-prefix': $slots.prefix || prefixIcon,
-        'st-input--with-suffix': $slots.suffix || suffixIcon,
-        'st-input--clearable': clearable,
         'st-input--close-visible': showCloseIcon,
       }
      ]"


### PR DESCRIPTION
    - Fixed clear icon visibility when disabled or readonly
    - Removed Firefox's outline when inner input is `:invalid`