### PR TITLE
TMC-485 | Fixed bug with grouped-pages displaying in Pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * Fixed dropdown's visibility in `Autocomplete`'s popper show/hide methods
 * `Input`'s prop `focusAfterClear` was set to false as default
 * Fixed bug with scrollbar height. Now scrollbar is absolute positioned.
+* Fixed bug in `Pagination` with displaying pages when `grouped-pages` amount is more than it possible to display
+* Removed click event on `Pagination`'s separators    
 
 
 

--- a/src/assets/scss/components/pagination/_variables.scss
+++ b/src/assets/scss/components/pagination/_variables.scss
@@ -5,12 +5,15 @@ $st-pagination-page-size: 28px !default;
 $st-pagination-page-margin: 14px !default;
 $st-pagination-page-padding: 0 5px !default;
 $st-pagination-page-border-radius: $st-pagination-page-size !default;
+$st-pagination-page-cursor: pointer !default;
 $st-pagination-icon-margin: 9px !default;
 $st-pagination-control-margin: 36px !default;
 $st-pagination-text-color: $st-color-dark-gunmetal !default;
 $st-pagination-current-page-bg-color: $st-color-dark-grey !default;
 $st-pagination-current-page-color: $st-color-white !default;
+$st-pagination-current-page-cursor: not-allowed !default;
 $st-pagination-separator-bg-color: transparent !default;
+$st-pagination-separator-cursor: not-allowed !default;
 $st-pagination-page-hover-bg-color: $st-color-solitude-white !default;
 $st-pagination-label-text-transformation: uppercase !default;
 

--- a/src/components/pagination/script.ts
+++ b/src/components/pagination/script.ts
@@ -120,18 +120,16 @@ export default class StPagination extends Vue {
 
     let minRange = separatedMinRange;
     let maxRange = separatedMaxRange;
+
     if (!hasFirstSeparator || !hasLastSeparator) {
       const minRangeWithSeparator = this.currentPage > lastBoundarySplit
         ? lastBoundarySplit
         : separatedMinRange;
-      const minRangeWithoutSeparator = this.currentPage > lastBoundarySplit
-        ? lastBoundarySplit
-        : boundarySecondFirstPage;
       const maxRangeWithSeparator = this.currentPage < firstBoundarySplit
         ? firstBoundarySplit
         : separatedMaxRange;
 
-      minRange = hasFirstSeparator ? minRangeWithSeparator : minRangeWithoutSeparator;
+      minRange = hasFirstSeparator ? minRangeWithSeparator : boundarySecondFirstPage;
       maxRange = hasLastSeparator ? maxRangeWithSeparator : boundarySecondLastPage;
     }
 
@@ -243,6 +241,10 @@ export default class StPagination extends Vue {
   onPageClick(page: number): void {
     if (page === 0 || page > this.totalPages) return;
     this.updateCurrentPage(page);
+  }
+
+  isPageType(type: PageType): boolean {
+    return type === PageType.page;
   }
 
   updateCurrentPage(pageNumber: number): void {

--- a/src/components/pagination/style.scss
+++ b/src/components/pagination/style.scss
@@ -22,7 +22,7 @@
     line-height: $st-pagination-page-size;
     color: $st-pagination-page-text-color;
     text-align: center;
-    cursor: pointer;
+    cursor: $st-pagination-page-cursor;
     border-radius: $st-pagination-page-border-radius;
 
     &:last-child {
@@ -35,7 +35,7 @@
 
     &--current {
       color: $st-pagination-current-page-color;
-      cursor: not-allowed;
+      cursor: $st-pagination-current-page-cursor;
       background-color: $st-pagination-current-page-bg-color;
 
       &:hover {
@@ -44,6 +44,7 @@
     }
 
     &--separator {
+      cursor: $st-pagination-separator-cursor;
       background-color: $st-pagination-separator-bg-color;
 
       &:hover {

--- a/src/components/pagination/template.html
+++ b/src/components/pagination/template.html
@@ -28,8 +28,8 @@
            'st-pagination__page--separator': page.type === PageType.separator
          }"
          :key="index"
-         @click="onPageClick(page.number)">
-      <template v-if="page.type === PageType.page">
+         @click="isPageType(page.type) ? onPageClick(page.number) : void 0">
+      <template v-if="isPageType(page.type)">
         {{ page.number }}
       </template>
       <template v-else>


### PR DESCRIPTION
* Fixed bug in `Pagination` with displaying pages when `grouped-pages` amount is more than it possible to display
* Removed click event on `Pagination`'s separators