### PR TITLE
TMC-492 | Fixed popper displaying bug with append-to-body prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.2.11
+
+### Features
+* `Autocomplete` prop `popperProps` was renamed to `dropdownProps`
+* Added max-width css property to `Autocomplete`'s popper
+* `Select` prop `dropdownPopperProps` was renamed to `dropdownProps`
+* `Select` and `Autocomplete` css style `width: 100%` was removed (in cause of popper displaying bug)
+* Added `Dropdown`'s prop `useReferenceWidth` to make dropdown's width same as its reference
+* `Dropdown`'s prop `appendToBody` was set to `true`
+
+
+
+
+
 ## 0.2.10
 
 ### Features

--- a/src/assets/scss/components/autocomplete/_variables.scss
+++ b/src/assets/scss/components/autocomplete/_variables.scss
@@ -1,7 +1,7 @@
 @import '../../utils/variables';
 
 // Dropdown
-$st-autocomplete-dropdown-width: 100% !default;
+$st-autocomplete-dropdown-min-width: 250px !default;
 
 // Message
 $st-autocomplete-message-padding: 10px !default;

--- a/src/assets/scss/components/select/_variables.scss
+++ b/src/assets/scss/components/select/_variables.scss
@@ -20,8 +20,6 @@ $st-select-arrow-icon-height: $st-select-arrow-icon-size !default;
 $st-select-arrow-icon-font-size: $st-select-arrow-icon-size !default;
 
 // Dropdown block
-$st-select-dropdown-width: 100% !default;
-
 $st-select-dropdown-readonly-option-cursor: default !default;
 $st-select-dropdown-disabled-option-cursor: default !default;
 

--- a/src/components/autocomplete/script.ts
+++ b/src/components/autocomplete/script.ts
@@ -79,14 +79,13 @@ export default class StAutocomplete extends Vue {
   loading!: boolean;
 
   @Prop({ type: Object, default: () => ({}) })
-  popperProps!: DropdownBindProperties;
+  dropdownProps!: DropdownBindProperties;
 
-  extendedPopperProps: DropdownBindProperties = {
+  extendedDropdownProps: DropdownBindProperties = {
     arrowVisible: false,
     placement: PopperPlacement.bottom,
     trigger: TriggerType.manual,
     boundariesSelector: 'body',
-    appendToBody: false,
   };
 
   inputValue: string = '';
@@ -122,8 +121,17 @@ export default class StAutocomplete extends Vue {
     }
   }
 
+  @Watch('dropdownProps')
+  onDropdownPropsChange(): void {
+    this.mergeDropdownProps();
+  }
+
   beforeMount(): void {
-    merge(this.extendedPopperProps, this.popperProps);
+    this.mergeDropdownProps();
+  }
+
+  mergeDropdownProps(): void {
+    merge(this.extendedDropdownProps, this.dropdownProps);
   }
 
   mounted(): void {

--- a/src/components/autocomplete/style.scss
+++ b/src/components/autocomplete/style.scss
@@ -13,5 +13,5 @@
 }
 
 .st-autocomplete-dropdown {
-  width: $st-autocomplete-dropdown-width;
+  min-width: $st-autocomplete-dropdown-min-width;
 }

--- a/src/components/autocomplete/template.html
+++ b/src/components/autocomplete/template.html
@@ -4,7 +4,7 @@
                ref="dropdown"
                :disabled="disabled"
                :value="popperVisibility"
-               v-bind="extendedPopperProps"
+               v-bind="extendedDropdownProps"
                @document-click="onDocClick">
     <st-input slot="reference"
               class="st-autocomplete__input"

--- a/src/components/dropdown/script.ts
+++ b/src/components/dropdown/script.ts
@@ -24,6 +24,9 @@ export default class StDropdown extends Vue {
   @Prop(Number)
   width?: number;
 
+  @Prop(Boolean)
+  useReferenceWidth?: boolean;
+
   @Prop(Number)
   maxHeight?: number;
 
@@ -39,7 +42,7 @@ export default class StDropdown extends Vue {
   @Prop({ type: String, default: PopperPlacement.bottom })
   placement!: string;
 
-  @Prop({ type: Boolean, default: false })
+  @Prop({ type: Boolean, default: true })
   appendToBody!: boolean;
 
   @Prop({ type: String, default: TriggerType.click })

--- a/src/components/select/_select-dropdown/script.ts
+++ b/src/components/select/_select-dropdown/script.ts
@@ -47,27 +47,26 @@ export default class StSelectDropdown extends Vue {
   readonly!: boolean;
 
   @Prop({ type: Object, default: () => {} })
-  popperProps!: DropdownBindProperties;
+  dropdownProps!: DropdownBindProperties;
 
-  extendedPopperProps: DropdownBindProperties = {
+  extendedDropdownProps: DropdownBindProperties = {
     arrowVisible: false,
     placement: PopperPlacement.bottom,
     trigger: TriggerType.click,
     boundariesSelector: 'body',
-    appendToBody: false,
   };
 
-  @Watch('popperProps')
-  onPopperPropsChange(): void {
-    this.mergePopperProps();
+  @Watch('dropdownProps')
+  onDropdownPropsChange(): void {
+    this.mergeDropdownProps();
   }
 
   beforeMount(): void {
-    this.mergePopperProps();
+    this.mergeDropdownProps();
   }
 
-  mergePopperProps(): void {
-    merge(this.extendedPopperProps, this.popperProps);
+  mergeDropdownProps(): void {
+    merge(this.extendedDropdownProps, this.dropdownProps);
   }
 
   select(option: SelectOption): void {

--- a/src/components/select/_select-dropdown/style.scss
+++ b/src/components/select/_select-dropdown/style.scss
@@ -1,5 +1,1 @@
 @import '../../../assets/scss/components/select/_variables';
-
-.st-select-dropdown {
-  width: $st-select-dropdown-width;
-}

--- a/src/components/select/_select-dropdown/template.html
+++ b/src/components/select/_select-dropdown/template.html
@@ -1,7 +1,7 @@
 <st-dropdown popper-class="st-select-dropdown"
              ref="dropdown"
              :disabled="disabled"
-             v-bind="extendedPopperProps"
+             v-bind="extendedDropdownProps"
              @show="$emit('dropdown-show')"
              @hide="$emit('dropdown-hide')">
   <template slot="reference">

--- a/src/components/select/_select-multiple/script.ts
+++ b/src/components/select/_select-multiple/script.ts
@@ -11,8 +11,8 @@ import StSelectDropdownScript from '../_select-dropdown/script';
 import StSelectBase from '../_select.base';
 import StCheckbox from '../../checkbox/index.vue';
 import StCollapser from '../../collapser/index.vue';
-import { DropdownBindProperties } from '../../dropdown/types';
 import {
+  PopperBindProperties,
   PopperPlacement,
   TriggerType,
 } from '../../popper/types';
@@ -36,7 +36,7 @@ export default class StSelectMultiple extends StSelectBase {
 
   selectedOptions: SelectOption[] = [];
 
-  extendedCollapserPopperProps: DropdownBindProperties = {
+  extendedCollapserPopperProps: PopperBindProperties = {
     arrowVisible: true,
     placement: PopperPlacement.top,
     trigger: TriggerType.hover,
@@ -60,15 +60,15 @@ export default class StSelectMultiple extends StSelectBase {
   }
 
   @Watch('collapserPopperProps')
-  onPopperPropsChange(): void {
-    this.mergePopperProps();
+  onCollapserPopperPropsChange(): void {
+    this.mergeCollapserPopperProps();
   }
 
   beforeMount(): void {
-    this.mergePopperProps();
+    this.mergeCollapserPopperProps();
   }
 
-  mergePopperProps(): void {
+  mergeCollapserPopperProps(): void {
     merge(this.extendedCollapserPopperProps, this.collapserPopperProps);
   }
 

--- a/src/components/select/_select-multiple/template.html
+++ b/src/components/select/_select-multiple/template.html
@@ -12,7 +12,7 @@
                     :readonly="readonly"
                     :selected-values="value"
                     :close-on-select="false"
-                    :popper-props="dropdownPopperProps"
+                    :dropdown-props="dropdownProps"
                     option-class="st-select-multiple__dropdown-option"
                     @select="select"
                     @dropdown-show="dropdownVisible = true; $emit('dropdown-show')"

--- a/src/components/select/_select-single/template.html
+++ b/src/components/select/_select-single/template.html
@@ -13,7 +13,7 @@
                     :selected-values="[value]"
                     :close-on-select="closeOnSelect"
                     option-class="st-select-single__dropdown-option"
-                    :popper-props="dropdownPopperProps"
+                    :dropdown-props="dropdownProps"
                     @select="select"
                     @dropdown-show="dropdownVisible = true; $emit('dropdown-show')"
                     @dropdown-hide="dropdownVisible = false; $emit('dropdown-hide')">

--- a/src/components/select/_select.base.ts
+++ b/src/components/select/_select.base.ts
@@ -47,7 +47,7 @@ export default class StSelectBase extends Vue {
   closeOnSelect!: boolean;
 
   @Prop({ type: Object, default: () => {} })
-  dropdownPopperProps!: DropdownBindProperties;
+  dropdownProps!: DropdownBindProperties;
 
   @Prop({ type: Object, default: () => {} })
   collapserPopperProps!: DropdownBindProperties;

--- a/src/components/select/template.html
+++ b/src/components/select/template.html
@@ -13,7 +13,7 @@
              :prefix-icon="prefixIcon"
              :suffix-icon="suffixIcon"
              :clear-icon-as-suffix-icon="clearIconAsSuffixIcon"
-             :dropdown-popper-props="dropdownPopperProps"
+             :dropdown-props="dropdownProps"
              :collapser-popper-props="collapserPopperProps"
              @input="$event => $emit('input', $event)"
              @select="$event => $emit('select', $event)"

--- a/stories/documentation/autocomplete.md
+++ b/stories/documentation/autocomplete.md
@@ -92,7 +92,7 @@ onSelect(suggestion) {
 | readonly | Defines readonly property | - | boolean | false | - |
 | placeholder | Search's input placeholder | - | string | - | - |
 | loading | Defines loading state | - | boolean | false | - |
-| popper-props | Dropdown popper's component properties | - | object | { arrowVisible: false, placement: bottom, trigger: click, boundariesSelector: 'body', appendToBody: false } | CHECK DROPDOWN COMPONENT DOCUMENTATION |
+| dropdown-props | Dropdown popper's component properties | - | object | { arrowVisible: false, placement: bottom, trigger: click, boundariesSelector: 'body', appendToBody: true } | CHECK DROPDOWN COMPONENT DOCUMENTATION |
 
 ## Events
 

--- a/stories/documentation/dropdown.md
+++ b/stories/documentation/dropdown.md
@@ -39,13 +39,14 @@ Here's an example with more information of usage:
 | --- | --- | --- | --- | --- | --- |
 | v-model | Dropdown visibility value (**with manual trigger only**) | false | boolean | - | - |
 | width | Dropdown width | false | number | - | - |
+| use-reference-width | set dropdown's width same as reference's one | false | boolean | false | - |
 | max-height | Dropdown max-height | false | number | - | - |
 | arrow-visible | Show or hide dropdown's arrow | false | boolean | false | - |
 | with-border | Show or hide dropdown's border | false | boolean | true | - |
 | popper-class | Additional dropdown's popper class | false | string | - | - |
 | placement | Dropdown priority placement | false | string | {{DEFAULT_PLACEMENT}} | {{AVAILABLE_PLACEMENTS}} |
 | trigger | Dropdown trigger type | false | string | {{DEFAULT_TRIGGER}} | {{AVAILABLE_TRIGGERS}} |
-| append-to-body | Append dropdown to body | false | boolean | false | - |
+| append-to-body | Append dropdown to body | false | boolean | true | - |
 | stop-propagation | Runs event.stopPropagation function | false | boolean | false | - |
 | prevent-default | Runs event.preventDefault function | false | boolean | false | - |
 | force-show | Dropdown's force visibility | false | boolean | false | - |

--- a/stories/documentation/popper.md
+++ b/stories/documentation/popper.md
@@ -7,6 +7,7 @@
 | v-model | manual popper trigger | false | boolean | - | - |
 | content | popper raw content | false | string | - | - |
 | width | popper width | false | number | - | - |
+| use-reference-width | set popper's width same as reference's one | false | boolean | false | - |
 | max-height | popper max-height | false | number | - | - |
 | tag | html tag for root element | false | string | span | - |
 | delay-on-mouse-over | delay mouse over on popper in milliseconds | false | number | 100 | - |

--- a/stories/documentation/select.md
+++ b/stories/documentation/select.md
@@ -70,12 +70,12 @@ Here's some examples:
 </st-select>
 ```
 
-Also you can change/extend inner dropdown's props via `dropdown-popper-props` (same with `collapser-popper-props`):
+Also you can change/extend inner dropdown's props via `dropdown-props` (same with `collapser-popper-props`):
 
 ```html
 <st-select v-model="singleValue" 
            :options="options" 
-           :dropdown-popper-props="{
+           :dropdown-props="{
              width: 400,
              maxHeight: 250,
              arrowVisible: true,
@@ -104,8 +104,8 @@ You can find out more about this component slots in the bottom of documentation.
 | close-on-clear | Close dropdown after clear event | - | Boolean | True | True / False |
 | close-on-select | **(Single Select only)** Close dropdown after select event | True | Boolean | False | True / False |
 | clear-icon-as-suffix-icon | Use suffix icon as clear icon. It will change suffix icon to cross when input isn't empty | - | Boolean | True | True / False |
-| dropdown-popper-props | Dropdown popper's component properties | - | Object | arrowVisible: false, placement: bottom, trigger: click, boundariesSelector: 'body' | CHECK POPPER COMPONENT DOCUMENTATION |
-| collapser-popper-props | **(Multiple Select only)** Collapser popper's component properties | - | Object | { arrowVisible: true, placement: top, trigger: hover, boundariesSelector: 'body', appendToBody: false } | CHECK DROPDOWN COMPONENT DOCUMENTATION |
+| dropdown-props | Dropdown popper's component properties | - | Object | arrowVisible: false, placement: bottom, trigger: click, boundariesSelector: 'body' | CHECK POPPER COMPONENT DOCUMENTATION |
+| collapser-popper-props | **(Multiple Select only)** Collapser popper's component properties | - | Object | { arrowVisible: true, placement: top, trigger: hover, boundariesSelector: 'body', appendToBody: true } | CHECK DROPDOWN COMPONENT DOCUMENTATION |
 
 ## Events
 


### PR DESCRIPTION
**Features**
* `Autocomplete` prop `popperProps` was renamed to `dropdownProps`
* Added max-width css property to `Autocomplete`'s popper
* `Select` prop `dropdownPopperProps` was renamed to `dropdownProps`
* `Select` and `Autocomplete` css style `width: 100%` was removed (in cause of popper displaying bug)
* Added `Dropdown`'s prop `useReferenceWidth` to make dropdown's width same as its reference
* `Dropdown`'s prop `appendToBody` was set to `true`