### PR TITLE
TMC-521 | Select component fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Maintenance
 * Updated `Notification` component. Do not show browser notifications when window is active
+* Fixed `Select`'s `list` slot. Didn't work before
+* Added `selected` key to `Select`'s `options` object. Useful for `option` slot
+
+
 
 
 ## 0.2.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Updated `Notification` component. Do not show browser notifications when window is active
 * Fixed `Select`'s `list` slot. Didn't work before
 * Added `selected` key to `Select`'s `options` object. Useful for `option` slot
+* Fixed `Popper` bug with placement while `useReferenceWidth` is on
 
 
 

--- a/src/components/popper/script.ts
+++ b/src/components/popper/script.ts
@@ -354,7 +354,13 @@ export default class StPopper extends Vue {
 
     updatedData.styles.width = `${width.toString()}px`;
     updatedData.offsets.popper.width = width;
-    updatedData.offsets.popper.left = left;
+
+    if ([
+      PopperPlacement.top,
+      PopperPlacement.bottom,
+    ].includes(data.placement as PopperPlacement)) {
+      updatedData.offsets.popper.left = left;
+    }
 
     return updatedData;
   }

--- a/src/components/select/_select-dropdown/template.html
+++ b/src/components/select/_select-dropdown/template.html
@@ -10,24 +10,26 @@
   <template slot="top">
     <slot name="dropdown-top" />
   </template>
-  <st-dropdown-option v-for="(option, index) in options"
-                      :key="option.value || index"
-                      :class="[
-                        'st-select-dropdown__option',
-                        optionClass,
-                        {
-                          'st-select-dropdown__option--selected': selectedValues && selectedValues.includes(option.value),
-                          [`${optionClass}--selected`]: optionClass && selectedValues && selectedValues.includes(option.value),
-                        }
-                      ]"
-                      :disabled="option.disabled"
-                      :readonly="readonly"
-                      @click="select(option)">
-    <slot name="option"
-          :option="option">
-      {{ option.label }}
-    </slot>
-  </st-dropdown-option>
+  <slot>
+    <st-dropdown-option v-for="(option, index) in options"
+                        :key="option.value || index"
+                        :class="[
+                          'st-select-dropdown__option',
+                          optionClass,
+                          {
+                            'st-select-dropdown__option--selected': option.selected,
+                            [`${optionClass}--selected`]: optionClass && option.selected,
+                          }
+                        ]"
+                        :disabled="option.disabled"
+                        :readonly="readonly || option.readonly"
+                        @click="select(option)">
+      <slot name="option"
+            :option="option">
+        {{ option.label }}
+      </slot>
+    </st-dropdown-option>
+  </slot>
   <template slot="bottom">
     <slot name="dropdown-bottom" />
   </template>

--- a/src/components/select/_select-multiple/script.ts
+++ b/src/components/select/_select-multiple/script.ts
@@ -44,6 +44,13 @@ export default class StSelectMultiple extends StSelectBase {
     stopPropagation: true,
   };
 
+  get updatedOptions(): SelectOption[] {
+    return this.options.map(option => ({
+      ...option,
+      selected: this.selectedValues && this.selectedValues.includes(option.value),
+    }));
+  }
+
   get selectedValues(): string[] {
     return this.selectedOptions.map((option: SelectOption) => option.value);
   }

--- a/src/components/select/_select-multiple/template.html
+++ b/src/components/select/_select-multiple/template.html
@@ -7,7 +7,7 @@
                       }
                     ]"
                     ref="dropdown"
-                    :options="options"
+                    :options="updatedOptions"
                     :disabled="disabled"
                     :readonly="readonly"
                     :selected-values="value"

--- a/src/components/select/_select-single/script.ts
+++ b/src/components/select/_select-single/script.ts
@@ -25,6 +25,13 @@ export default class StSelectSingle extends StSelectBase {
 
   dropdownVisible: boolean = false;
 
+  get updatedOptions(): SelectOption[] {
+    return this.options.map(option => ({
+      ...option,
+      selected: this.selectedOption && this.selectedOption.value === option.value,
+    }));
+  }
+
 
   get selectedOption(): SelectOption | undefined {
     return this.options.find((option: SelectOption) => option && option.value === this.value);

--- a/src/components/select/_select-single/template.html
+++ b/src/components/select/_select-single/template.html
@@ -7,7 +7,7 @@
                       }
                     ]"
                     ref="dropdown"
-                    :options="options"
+                    :options="updatedOptions"
                     :disabled="disabled"
                     :readonly="readonly"
                     :selected-values="[value]"

--- a/src/components/select/types.ts
+++ b/src/components/select/types.ts
@@ -1,5 +1,7 @@
 export interface SelectOption {
   label: string;
   value: string;
+  selected?: boolean;
+  readonly?: boolean;
   disabled?: boolean;
 }

--- a/stories/pages/dropdown/default.stories.js
+++ b/stories/pages/dropdown/default.stories.js
@@ -43,6 +43,9 @@ storiesOf('Components|Dropdown', module).add('Default', () => ({
     readonly: {
       default: boolean('*DROPDOWN-OPTIONS | readonly', false),
     },
+    useReferenceWidth: {
+      default: boolean('Use reference width', false),
+    },
   },
   data() {
     return {}

--- a/stories/pages/popper/default.stories.js
+++ b/stories/pages/popper/default.stories.js
@@ -47,6 +47,9 @@ storiesOf('Components|Popper', module).add('Default', () => ({
     appendToBody: {
       default: boolean('Append to body', true),
     },
+    useReferenceWidth: {
+      default: boolean('Use reference width', false),
+    }
   },
   data() {
     return {

--- a/stories/templates/dropdown/default.template.js
+++ b/stories/templates/dropdown/default.template.js
@@ -8,6 +8,7 @@ export const template = `
                :disabled="disabled"
                :force-show="forceShow"
                :append-to-body="appendToBody"
+               :use-reference-width="useReferenceWidth"
                :delay-on-mouse-over="delayOnMouseOver"
                :delay-on-mouse-out="delayOnMouseOut">
     <st-button slot="reference"

--- a/stories/templates/popper/default.template.js
+++ b/stories/templates/popper/default.template.js
@@ -11,6 +11,7 @@ export const template = `
              :disabled="disabled"
              :force-show="forceShow"
              :append-to-body="appendToBody"
+             :use-reference-width="useReferenceWidth"
              v-model="value"
              :placement="placement">
     <div class="content">


### PR DESCRIPTION
**Maintenance**
* Fixed `Select`'s `list` slot. Didn't work before
* Added `selected` key to `Select`'s `options` object. Useful for `option` slot
* Fixed `Popper` bug with placement while `useReferenceWidth` is on